### PR TITLE
ci: run pull request tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Test
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint, type-check, and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.14.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm exec eslint .
+
+      - name: Type-check
+        run: pnpm compile
+
+      - name: Unit tests
+        run: pnpm test:unit
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: pnpm test:e2e

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,19 +1,4 @@
-import { existsSync } from 'node:fs'
-import process from 'node:process'
 import { defineConfig } from '@playwright/test'
-
-const chromiumExecutablePath = [
-  process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE,
-  'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-  'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
-  'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
-  'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
-  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-  '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-  '/usr/bin/google-chrome',
-  '/usr/bin/chromium',
-  '/usr/bin/chromium-browser',
-].find((value): value is string => Boolean(value && existsSync(value)))
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -25,9 +10,6 @@ export default defineConfig({
   reporter: 'list',
   use: {
     browserName: 'chromium',
-    launchOptions: chromiumExecutablePath
-      ? { executablePath: chromiumExecutablePath }
-      : undefined,
     trace: 'retain-on-failure',
   },
 })


### PR DESCRIPTION
## Summary

- Add a pull request GitHub Actions workflow for linting, type-checking, unit tests, and e2e tests.
- Install Playwright Chromium in CI before running e2e tests.
- Remove the local Chrome/Edge executable fallback from Playwright config so e2e requires Playwright-managed browsers.

## Validation

- `pnpm exec eslint . --fix`
- `pnpm exec eslint .`
- `pnpm compile`
- `pnpm test:unit`

## Notes

- Local `pnpm test:e2e` built the Chrome extension, then failed because Playwright Chromium was not installed.
- Local `pnpm exec playwright install chromium` exceeded the 5-minute desktop timeout. The CI workflow now runs `pnpm exec playwright install --with-deps chromium` before e2e tests.