### PR TITLE
docs(readme): update tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ pnpm test:e2e
 
 ## Tech Stack
 
+- [pnpm](https://pnpm.io/) for package management
 - [WXT](https://wxt.dev/) for browser extension development
-- [Vue 3](https://vuejs.org/) for the DevTools panel UI
-- [Element Plus](https://element-plus.org/) and [Tailwind CSS](https://tailwindcss.com/) for interface components and styling
-- TypeScript and `vue-tsc` for type checking
+- [Vue 3](https://vuejs.org/) with TypeScript for the DevTools panel UI
+- shadcn-vue style local components, [Reka UI](https://reka-ui.com/), and [lucide-vue-next](https://lucide.dev/) for UI primitives and icons
+- [Tailwind CSS v4](https://tailwindcss.com/) for styling and design tokens
+- `vue-tsc`, [Vitest](https://vitest.dev/), and [Playwright](https://playwright.dev/) for type checking and verification
 - WXT/browser `i18n` for localized messages
 
 ## Inspiration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,10 +100,12 @@ pnpm test:e2e
 
 ## 技术栈
 
+- [pnpm](https://pnpm.io/) 用于包管理
 - [WXT](https://wxt.dev/) 用于浏览器扩展开发
-- [Vue 3](https://vuejs.org/) 用于 DevTools 面板 UI
-- [Element Plus](https://element-plus.org/) 和 [Tailwind CSS](https://tailwindcss.com/) 用于界面组件与样式
-- TypeScript 和 `vue-tsc` 用于类型检查
+- [Vue 3](https://vuejs.org/) 搭配 TypeScript 用于 DevTools 面板 UI
+- shadcn-vue 风格的本地组件、[Reka UI](https://reka-ui.com/) 和 [lucide-vue-next](https://lucide.dev/) 用于 UI 基础组件与图标
+- [Tailwind CSS v4](https://tailwindcss.com/) 用于样式和设计 token
+- `vue-tsc`、[Vitest](https://vitest.dev/) 和 [Playwright](https://playwright.dev/) 用于类型检查与验证
 - WXT/browser `i18n` 用于本地化文案
 
 ## 灵感来源


### PR DESCRIPTION
## What changed

- Updated the English and Simplified Chinese README tech stack sections.
- Removed stale Element Plus references.
- Documented the current stack: pnpm, WXT, Vue 3 + TypeScript, shadcn-vue style local components, Reka UI, lucide-vue-next, Tailwind CSS v4, vue-tsc, Vitest, Playwright, and WXT/browser i18n.

## Why

The README tech stack was out of date after the DevTools panel moved to the current UI/tooling stack.

## Verification

- `pnpm exec eslint . --fix`
- `git diff --check`