### PR TITLE
fix: default locale to English

### DIFF
--- a/entrypoints/devtools-panel/lang.ts
+++ b/entrypoints/devtools-panel/lang.ts
@@ -44,8 +44,8 @@ const messages = {
 
 export const activeLocale = ref<Locale>('en')
 
-export function initializeLocale(value: string | null, fallback = browser.i18n.getUILanguage()) {
-  activeLocale.value = resolveLocale(value ?? fallback)
+export function initializeLocale(value: string | null) {
+  activeLocale.value = resolveLocale(value)
 }
 
 export function setLocale(value: Locale) {

--- a/tests/unit/lang.test.ts
+++ b/tests/unit/lang.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fakeBrowser } from 'wxt/testing'
+import { activeLocale, initializeLocale } from '../../entrypoints/devtools-panel/lang'
+
+describe('language initialization', () => {
+  it('defaults to English when the user has not selected a language', () => {
+    vi.spyOn(fakeBrowser.i18n, 'getUILanguage').mockReturnValue('zh-CN')
+
+    initializeLocale(null)
+
+    expect(activeLocale.value).toBe('en')
+  })
+
+  it('uses the saved language when the user has selected one', () => {
+    initializeLocale('zh_CN')
+
+    expect(activeLocale.value).toBe('zh_CN')
+  })
+})


### PR DESCRIPTION
## Summary

- Default the DevTools panel language to English when the user has not selected a language.
- Keep using the saved locale when the user manually changes the language.
- Add unit coverage for language initialization.

## Why

Previously, initialization fell back to `browser.i18n.getUILanguage()`, so a Chinese browser UI automatically selected Simplified Chinese even when the user had not chosen a language.

## Verification

- `pnpm exec eslint . --fix`
- `pnpm compile`
- `pnpm test:unit`