### PR TITLE
ci: add build and zip checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,36 @@ jobs:
 
       - name: E2E tests
         run: pnpm test:e2e
+
+  package:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Build
+            command: pnpm build
+          - name: Zip
+            command: pnpm zip
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.14.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.command }}


### PR DESCRIPTION
## What changed

- Added a parallel packaging job to the PR test workflow.
- The new matrix job validates both `pnpm build` and `pnpm zip`.

## Why

PR checks should catch browser extension build and package failures before merge, while still allowing the existing test job to run in parallel.

## Validation

- `pnpm exec eslint . --fix`
- `pnpm exec wxt prepare`
- `pnpm build`
- `pnpm zip`